### PR TITLE
Ease the use of in-memory storage driver in Converse

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -3,11 +3,12 @@
  */
 import * as localForage from "localforage";
 import * as memoryDriver from 'localforage-driver-memory';
-const IN_MEMORY = memoryDriver._driver
-localForage.defineDriver(memoryDriver);
 import cloneDeep from 'lodash-es/cloneDeep.js';
 import isString from 'lodash-es/isString.js';
 import sessionStorageWrapper from "./drivers/sessionStorage.js";
+
+const IN_MEMORY = memoryDriver._driver
+localForage.defineDriver(memoryDriver);
 
 function S4() {
     // Generate four random hex digits.

--- a/src/storage.js
+++ b/src/storage.js
@@ -3,6 +3,8 @@
  */
 import * as localForage from "localforage";
 import * as memoryDriver from 'localforage-driver-memory';
+const IN_MEMORY = memoryDriver._driver
+localForage.defineDriver(memoryDriver);
 import cloneDeep from 'lodash-es/cloneDeep.js';
 import isString from 'lodash-es/isString.js';
 import sessionStorageWrapper from "./drivers/sessionStorage.js";
@@ -41,8 +43,7 @@ class Storage {
         } else if (type === 'local') {
             await localForage.config({'driver': localForage.LOCALSTORAGE});
         } else if (type === 'in_memory') {
-            localForage.defineDriver(memoryDriver);
-            localForage.setDriver(memoryDriver._driver);
+            localForage.config({'driver': IN_MEMORY});
         } else if (type !== 'indexed') {
             throw new Error("Skeletor.storage: No storage type was specified");
         }


### PR DESCRIPTION
This PR adds the in-memory driver name to a constant inside of Storage so that it can be referenced from the project using the library when choosing that driver.
The purpose is for the driver to be used in a similar fashion like the default ones for localForage: https://github.com/conversejs/converse.js/blob/master/src/headless/core.js#L1000
Like this: https://github.com/conversejs/converse.js/pull/2356/files#diff-a3f31229725baf4cbd2ab23be014f043270bd36ccfc7175a197a2cc81287e6f0R1003