### PR TITLE
Import the default export of localforage

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -2,7 +2,7 @@
  * IndexedDB, localStorage and sessionStorage adapter
  */
 import mergebounce from 'mergebounce';
-import * as localForage from "localforage";
+import localForage from "localforage/src/localforage";
 import * as memoryDriver from 'localforage-driver-memory';
 import cloneDeep from 'lodash-es/cloneDeep.js';
 import isString from 'lodash-es/isString.js';


### PR DESCRIPTION
When imported in an ES module, the `localForage` prop of `Storage` is missing some methods

    Error Uncaught (in promise) TypeError: Storage.localForage.createInstance is not a function
